### PR TITLE
Add support for optional State parameter in SetImage and SetTitle events

### DIFF
--- a/streamdeck-client-csharp/Messages/SetImageMessage.cs
+++ b/streamdeck-client-csharp/Messages/SetImageMessage.cs
@@ -13,10 +13,10 @@ namespace streamdeck_client_csharp.Messages
         [JsonProperty("payload")]
         public IPayload Payload { get; private set; }
 
-        public SetImageMessage(string base64Image, string context, SDKTarget target)
+        public SetImageMessage(string base64Image, string context, SDKTarget target, int? state)
         {
             this.Context = context;
-            this.Payload = new PayloadClass(base64Image, target);
+            this.Payload = new PayloadClass(base64Image, target, state);
         }
 
         private class PayloadClass : IPayload
@@ -27,10 +27,14 @@ namespace streamdeck_client_csharp.Messages
             [JsonProperty("target")]
             public SDKTarget Target { get; private set; }
 
-            public PayloadClass(string image, SDKTarget target)
+            [JsonProperty("state", NullValueHandling = NullValueHandling.Ignore)]
+            public int? State { get; private set; }
+
+            public PayloadClass(string image, SDKTarget target, int? state)
             {
                 this.Image = image;
                 this.Target = target;
+                this.State = state;
             }
         }
     }

--- a/streamdeck-client-csharp/Messages/SetTitleMessage.cs
+++ b/streamdeck-client-csharp/Messages/SetTitleMessage.cs
@@ -13,10 +13,10 @@ namespace streamdeck_client_csharp.Messages
         [JsonProperty("payload")]
         public IPayload Payload { get; private set; }
 
-        public SetTitleMessage(string title, string context, SDKTarget target)
+        public SetTitleMessage(string title, string context, SDKTarget target, int? state)
         {
             this.Context = context;
-            this.Payload = new PayloadClass(title, target);
+            this.Payload = new PayloadClass(title, target, state);
         }
 
         private class PayloadClass : IPayload
@@ -27,10 +27,14 @@ namespace streamdeck_client_csharp.Messages
             [JsonProperty("target")]
             public SDKTarget Target { get; private set; }
 
-            public PayloadClass(string title, SDKTarget target)
+            [JsonProperty("state", NullValueHandling = NullValueHandling.Ignore)]
+            public int? State { get; private set; }
+
+            public PayloadClass(string title, SDKTarget target, int? state)
             {
                 this.Title = title;
                 this.Target = target;
+                this.State = state;
             }
         }
     }

--- a/streamdeck-client-csharp/StreamDeckConnection.cs
+++ b/streamdeck-client-csharp/StreamDeckConnection.cs
@@ -71,9 +71,9 @@ namespace streamdeck_client_csharp
             m_CancelSource.Cancel();
         }
 
-        public Task SetTitleAsync(string title, string context, SDKTarget target)
+        public Task SetTitleAsync(string title, string context, SDKTarget target, int? state)
         {
-            return SendAsync(new SetTitleMessage(title, context, target));
+            return SendAsync(new SetTitleMessage(title, context, target, state));
         }
 
         public Task LogMessageAsync(string message)
@@ -81,7 +81,7 @@ namespace streamdeck_client_csharp
             return SendAsync(new LogMessage(message));
         }
 
-        public Task SetImageAsync(Image image, string context, SDKTarget target)
+        public Task SetImageAsync(Image image, string context, SDKTarget target, int? state)
         {
             using (MemoryStream memoryStream = new MemoryStream())
             {
@@ -90,13 +90,13 @@ namespace streamdeck_client_csharp
 
                 // Convert byte[] to Base64 String
                 string base64String = $"data:image/png;base64,{Convert.ToBase64String(imageBytes)}";
-                return SetImageAsync(base64String, context, target);
+                return SetImageAsync(base64String, context, target, state);
             }
         }
 
-        public Task SetImageAsync(string base64Image, string context, SDKTarget target)
+        public Task SetImageAsync(string base64Image, string context, SDKTarget target, int? state)
         {
-            return SendAsync(new SetImageMessage(base64Image, context, target));
+            return SendAsync(new SetImageMessage(base64Image, context, target, state));
         }
 
         public Task ShowAlertAsync(string context)


### PR DESCRIPTION
New optional state parameter in setTitle and setImage APIs,
state: A 0-based integer value representing the state of an action with multiple states. This is an optional parameter. If not specified, the title is set to all states.